### PR TITLE
chore: update criteria for outdated themes (#318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ In any other case, if a submission is found to be in violation of licence of the
 Themes with READMEs set up as marketing campaigns for other products (e.g. paid version of a free theme) will not be accepted.
 
 
-# Note on outdated themes
+# Outdated themes
 
-Themes that have not been updated in the past few years are removed as per the current policy. Even if your theme is fully functional, it is recommended that you periodically check and confirm its compatibility with the latest versions of Hugo.
+According to our current policy, themes that have not been updated within the last 3 years are deemed outdated and are removed. Even if your theme is fully functional, it is recommended that you periodically check and confirm its compatibility with the latest version of Hugo.
 
 # FAQ
 

--- a/pkg/buildcmd/build.go
+++ b/pkg/buildcmd/build.go
@@ -413,7 +413,7 @@ func (t *theme) checkLastMod() (warn warning, found bool) {
 	if !lastMod.IsZero() {
 		age := time.Since(lastMod)
 		ageYears := age.Hours() / 24 / 365
-		if ageYears > 2 {
+		if ageYears > 3 {
 			warn = themeWarningOld
 			found = true
 		}


### PR DESCRIPTION
* chore: update criteria for outdated themes
* chore: update docs regarding outdated themes Themes that are not modified for more than 3 years will be considered as outdated.